### PR TITLE
Fix: Switching NodeJS Base Url to 'api/v1'

### DIFF
--- a/backend/nodejs/app.js
+++ b/backend/nodejs/app.js
@@ -9,12 +9,12 @@ const port = process.env.PORT || 3000;
 app.use(bodyParser.json());
 app.use(cors());
 
-// Route for the root URL  
-app.get('/', (req, res) => {
+// Route for the base URL  
+app.get('/api/v1', (req, res) => {
   res.send('Hello World');
 });
 
-// Start the server
+// Start the server: Comment this code out if you're running tests
 // app.listen(port, () => {
 //   console.log(`Server started on port ${port}`);
 // });

--- a/backend/nodejs/tests/hello-world.test.js
+++ b/backend/nodejs/tests/hello-world.test.js
@@ -1,7 +1,7 @@
 const request = require('supertest');
 const app = require('../app');
 
-describe('GET /', () => {
+describe('GET /api/v1', () => {
   let server; // Declare a variable to hold the server instance
 
   beforeAll(() => {
@@ -15,7 +15,7 @@ describe('GET /', () => {
   });
 
   it('responds with "Hello World"', async () => {
-    const response = await request(app).get('/');
+    const response = await request(app).get('/api/v1');
     expect(response.status).toBe(200);
     expect(response.text).toBe('Hello World');
   });


### PR DESCRIPTION
Title: Switching NodeJS Base API URL from `/` to `/api/v1`
Description: I edited the code, to make sure that it's the `/api/v1` route that returns Hello World. I also changed the tests so they meet the requirements.
Team: BE#11